### PR TITLE
set model revisions

### DIFF
--- a/scripts/TheBloke_Upstage-Llama-2-70B-instruct-v2-AWQ.sh
+++ b/scripts/TheBloke_Upstage-Llama-2-70B-instruct-v2-AWQ.sh
@@ -4,6 +4,8 @@
 # - required because this model is quantized:`--quantize awq` (this, again, requires `text-generation-inference>=1.10`)
 
 MODEL_ID=TheBloke/Upstage-Llama-2-70B-instruct-v2-AWQ
+REVISION=6ffd8b58998a28840e40a97606074f80429ca5cf
+
 srun -K \
 --container-image=/netscratch/enroot/huggingface_text-generation-inference_1.1.0.sqsh \
 --container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME \
@@ -11,8 +13,9 @@ srun -K \
 -p A100-PCI \
 --mem 64GB \
 --gpus 1 \
---export MODEL_ID=$MODEL_ID \
 text-generation-launcher \
+--model_id $MODEL_ID \
+--revision $REVISION \
 --quantize awq \
 --max-batch-prefill-tokens 1024 \
 --port 5000

--- a/scripts/TheBloke_em_german_leo_mistral-AWQ.sh
+++ b/scripts/TheBloke_em_german_leo_mistral-AWQ.sh
@@ -5,6 +5,8 @@
 # - prompt format: Du bist ein hilfreicher Assistent. USER: <instruction> ASSISTANT:
 
 MODEL_ID=TheBloke/em_german_leo_mistral-AWQ
+REVISION=54c7dd05b55124aab3450f94203e1970f9286445
+
 srun -K \
 --container-image=/netscratch/enroot/huggingface_text-generation-inference_1.1.0.sqsh \
 --container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME \
@@ -12,8 +14,9 @@ srun -K \
 -p A100-PCI \
 --mem 64GB \
 --gpus 1 \
---export MODEL_ID=$MODEL_ID \
 text-generation-launcher \
+--model_id $MODEL_ID \
+--revision $REVISION \
 --quantize awq \
 --max-batch-prefill-tokens 1024 \
 --port 5000

--- a/scripts/google_flan-t5-large.sh
+++ b/scripts/google_flan-t5-large.sh
@@ -1,17 +1,16 @@
 # NOTES:
-# - model card: https://huggingface.co/lmsys/vicuna-13b-v1.5
-# Works on A100-40GB, A100-PCI, RTX3090
-# Doesn't work on RTX6000
+# - model card: https://huggingface.co/google/flan-t5-large
+# Works on A100-40GB, A100-PCI V100-32GB, RTX6000, RTX3090
 
 srun -K \
---container-image=/netscratch/enroot/huggingface_text-generation-inference_1.1.0.sqsh \
---container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME     \
---container-workdir=$HOME       \
--p A100-40GB     \
---mem 64GB \
---gpus 1       \
---export MODEL_ID=lmsys/vicuna-13b-v1.5 \
+--container-image=/netscratch/enroot/text-generation-inference_1.0.3.sqsh \
+--container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME \
+--container-workdir=$HOME \
+-p RTX3090 \
+--mem 16GB --gpus 1 \
 text-generation-launcher \
+--model_id google/flan-t5-large \
+--revision 0613663d0d48ea86ba8cb3d7a44f0f65dc596a2a \
 --port 5000
 
 # HOW-TO ACCESS THE (EXECUTABLE) API DOCUMENTATION:
@@ -21,5 +20,3 @@ text-generation-launcher \
 # This should give you a list of jobs, each with a node name in the "NODELIST(REASON)" column, e.g. "serv-3316".
 # Then, you can access the API documentation at the following endpoint (replace $NODE with the node name):
 # http://$NODE.kl.dfki.de:5000/docs
-
-

--- a/scripts/lmsys_vicuna-13b-v1.5.sh
+++ b/scripts/lmsys_vicuna-13b-v1.5.sh
@@ -1,15 +1,18 @@
 # NOTES:
-# - model card: https://huggingface.co/google/flan-t5-large
-# Works on A100-40GB, A100-PCI V100-32GB, RTX6000, RTX3090
+# - model card: https://huggingface.co/lmsys/vicuna-13b-v1.5
+# Works on A100-40GB, A100-PCI, RTX3090
+# Doesn't work on RTX6000
 
 srun -K \
---container-image=/netscratch/enroot/text-generation-inference_1.0.3.sqsh \
---container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME \
---container-workdir=$HOME \
--p RTX3090 \
---mem 16GB --gpus 1 \
---export MODEL_ID=google/flan-t5-large \
+--container-image=/netscratch/enroot/huggingface_text-generation-inference_1.1.0.sqsh \
+--container-mounts=/netscratch:/netscratch,/ds:/ds,/ds/models/llms/cache:/data,$HOME:$HOME     \
+--container-workdir=$HOME       \
+-p A100-40GB     \
+--mem 64GB \
+--gpus 1       \
 text-generation-launcher \
+--model_id lmsys/vicuna-13b-v1.5 \
+--revision de56c35b1763eaae20f4d60efd64af0a9091ebe5 \
 --port 5000
 
 # HOW-TO ACCESS THE (EXECUTABLE) API DOCUMENTATION:
@@ -19,3 +22,5 @@ text-generation-launcher \
 # This should give you a list of jobs, each with a node name in the "NODELIST(REASON)" column, e.g. "serv-3316".
 # Then, you can access the API documentation at the following endpoint (replace $NODE with the node name):
 # http://$NODE.kl.dfki.de:5000/docs
+
+

--- a/scripts/lmsys_vicuna-7b-v1.5.sh
+++ b/scripts/lmsys_vicuna-7b-v1.5.sh
@@ -10,8 +10,9 @@ srun -K \
 -p A100-40GB     \
 --mem 64GB \
 --gpus 1       \
---export MODEL_ID=lmsys/vicuna-7b-v1.5 \
 text-generation-launcher \
+--model_id lmsys/vicuna-7b-v1.5 \
+--revision de56c35b1763eaae20f4d60efd64af0a9091ebe5 \
 --port 5000
 
 # HOW-TO ACCESS THE (EXECUTABLE) API DOCUMENTATION:


### PR DESCRIPTION
To prevent any breaking by future changes of the models at huggingface.co. 

This also avoids an issue where a user can not start the model in the case that not this user but another one started it the first time. This was only a problem if the model changed on the hub and ITG wanted to download the updated versions which it couldn't because it does not had the rights to overwrite the original files. This is still the case, but at least this does not happen silently anymore (just on explicit change of revision).